### PR TITLE
Fix issue with hex alpha parsing and add tests

### DIFF
--- a/src/main/java/org/beryx/awt/color/ColorFactory.java
+++ b/src/main/java/org/beryx/awt/color/ColorFactory.java
@@ -274,7 +274,7 @@ public final class ColorFactory {
 				g = Integer.parseInt(color.substring(2, 4), 16);
 				b = Integer.parseInt(color.substring(4, 6), 16);
 				a = Integer.parseInt(color.substring(6, 8), 16);
-				return new Color(r, g, b, (float)(opacity * a / 255.0));
+				return new Color(r, g, b, (int)(opacity * a + 0.5));
 			}
 		} catch (NumberFormatException nfe) {}
 

--- a/src/test/java/org/beryx/awt/color/ColorFactoryTest.java
+++ b/src/test/java/org/beryx/awt/color/ColorFactoryTest.java
@@ -30,6 +30,8 @@ public class ColorFactoryTest {
         assertEquals(ColorFactory.FIREBRICK, ColorFactory.valueOf("firebrick"));
         assertEquals(new Color(170, 56, 224), ColorFactory.valueOf("#aa38e0"));
         assertEquals(new Color(64, 168, 204), ColorFactory.valueOf("0x40A8CC"));
+        assertEquals(new Color(0, 255, 255, 100), ColorFactory.valueOf("00FFFF64"));
+        assertEquals(new Color(0, 255, 255, 102), ColorFactory.valueOf("0FF6"));
         assertEquals(new Color(112, 36, 228, (int)(0.9 * 255 + 0.5)), ColorFactory.valueOf("rgba(112,36,228,0.9)"));
         assertEquals(new Color(128, 0, 255), ColorFactory.valueOf("hsla(270,100%,100%,1.0)"));
     }
@@ -40,5 +42,7 @@ public class ColorFactoryTest {
         assertEquals(new Color(64, 168, 204, (int)(0.7 * 255 + 0.5)), ColorFactory.web("0x40A8CC", 0.7));
         assertEquals(new Color(34, 139, 34, (int)(0.6 * 255 + 0.5)), ColorFactory.web("forestgreen", 0.6));
         assertEquals(new Color(98, 18, 179, (int)(0.8 * 255 + 0.5)), ColorFactory.web("hsl(270,90%,70%)", 0.8));
+        assertEquals(new Color(0, 255, 255, 100), ColorFactory.valueOf("00FFFF64"));
+        assertEquals(new Color(0, 255, 255, 102), ColorFactory.valueOf("0FF6"));
     }
 }


### PR DESCRIPTION
Hex colours with alpha (e.g. `0x00FFFF64`) don't get parsed properly.